### PR TITLE
Downgrade rust-protobuf to 2.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,24 +128,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf"
-version = "3.0.0-pre"
-source = "git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f#76c8892a410fa7a3d74041332c20fb2b1a74f71f"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.0.0-pre"
-source = "git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f#76c8892a410fa7a3d74041332c20fb2b1a74f71f"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "protobuf-codegen-pure"
-version = "3.0.0-pre"
-source = "git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f#76c8892a410fa7a3d74041332c20fb2b1a74f71f"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "protobuf 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)",
- "protobuf-codegen 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -159,8 +159,8 @@ version = "0.0.1"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "protobuf 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)",
- "protobuf-codegen-pure 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)",
+ "protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen-pure 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -242,9 +242,9 @@ dependencies = [
 "checksum libflate 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "76912aa0196b6f0e06d9c43ee877be45369157c06172ade12fe20ac3ee5ffa15"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "780fb4b6698bbf9cf2444ea5d22411cef2953f0824b98f33cf454ec5615645bd"
-"checksum protobuf 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)" = "<none>"
-"checksum protobuf-codegen 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)" = "<none>"
-"checksum protobuf-codegen-pure 3.0.0-pre (git+https://github.com/stepancheg/rust-protobuf?rev=76c8892a410fa7a3d74041332c20fb2b1a74f71f)" = "<none>"
+"checksum protobuf 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f00e4a3cb64ecfeac2c0a73c74c68ae3439d7a6bead3870be56ad5dd2620a6f"
+"checksum protobuf-codegen 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2c6e555166cdb646306f599da020e01548e9f4d6ec2fd39802c6db2347cbd3e"
+"checksum protobuf-codegen-pure 2.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a7c75610cc3f41f4d2c1e048d6e4f857361cf26e63b3faf0b3ba1331c94b21"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,9 @@ license = "Apache-2.0"
 [dependencies]
 fnv = "1.0.6"
 hex = "0.3.2"
+protobuf = "2.7.0"
 sha2 = "0.8.0"
 zip = "0.5.2"
 
-[dependencies.protobuf]
-git = "https://github.com/stepancheg/rust-protobuf"
-rev = "76c8892a410fa7a3d74041332c20fb2b1a74f71f"
-
-[build-dependencies.protobuf-codegen-pure]
-git = "https://github.com/stepancheg/rust-protobuf"
-rev = "76c8892a410fa7a3d74041332c20fb2b1a74f71f"
+[build-dependencies]
+protobuf-codegen-pure = "2.7.0"

--- a/build.rs
+++ b/build.rs
@@ -24,23 +24,15 @@ fn main() {
     std::fs::create_dir_all(out_dir).expect("mkdir -p");
     extern crate protobuf_codegen_pure;
 
-    protobuf_codegen_pure::Args::new()
-        .out_dir(out_dir)
-        .inputs(inputs)
-        .include("protos")
-        .customize(protobuf_codegen_pure::Customize {
-            singular_field_option_box: Some(true),
+    protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
+        out_dir,
+        input: inputs,
+        includes: &["protos"],
+        customize: protobuf_codegen_pure::Customize {
             ..Default::default()
-        })
-        .run()
-        .expect("protoc");
-
-    // NOTE(MH): Patch the generated Rust file to remedy an bug in the codegen
-    // until we have a fix.
-    sed_in_place(
-        "src/protos/da/daml_lf_1.rs",
-        "s/def_template::def_key::/def_key::/",
-    );
+        },
+    })
+    .expect("protoc");
 
     // NOTE(MH): The protobuf codegen produces `#[allow(clippy)]` pragmas,
     // which cause a clippy warning. Thus we need to patch it.


### PR DESCRIPTION
rust-protobuf 3.0.0 has a known security vulnerability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/rusty-engine/3)
<!-- Reviewable:end -->
