### PR TITLE
Implement closure conversion

### DIFF
--- a/src/ast/closure_conversion.rs
+++ b/src/ast/closure_conversion.rs
@@ -1,0 +1,113 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+use std::collections::{HashMap, HashSet};
+
+use super::Expr;
+
+fn rewrite_index(index: &mut usize, rewrite: &HashMap<usize, usize>, offset: usize) {
+    if *index > offset {
+        if let Some(new_index) = rewrite.get(&(*index - offset)) {
+            *index = *new_index + offset;
+        }
+    }
+}
+
+fn rewrite_expr(expr: &mut Expr, rewrite: &HashMap<usize, usize>, offset: usize) {
+    use Expr::*;
+    match expr {
+        Var { index, .. } => {
+            rewrite_index(index, rewrite, offset);
+        }
+        Lam {
+            params: _,
+            captured,
+            body: _,
+        } => {
+            for index in captured {
+                rewrite_index(index, rewrite, offset);
+            }
+        }
+        Let { bound, body, .. } => {
+            rewrite_expr(bound, rewrite, offset);
+            rewrite_expr(body, rewrite, offset + 1);
+        }
+        Case { scrut, alts } => {
+            rewrite_expr(scrut, rewrite, offset);
+            for alt in alts {
+                rewrite_expr(&mut alt.body, rewrite, offset + alt.pattern.binders().len());
+            }
+        }
+        _ => {
+            for child in expr.children_mut() {
+                rewrite_expr(child, rewrite, offset);
+            }
+        }
+    }
+}
+
+fn unshift_fv(fv: HashSet<usize>, offset: usize) -> HashSet<usize> {
+    fv.into_iter()
+        .filter_map(|index| {
+            if index > offset {
+                Some(index - offset)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn convert_fv(expr: &mut Expr) -> HashSet<usize> {
+    use Expr::*;
+    match expr {
+        Var { index, .. } => [*index].iter().copied().collect(),
+        Lam {
+            params,
+            captured,
+            body,
+        } => {
+            let arity = params.len();
+            let fv = unshift_fv(convert_fv(body), arity);
+            let mut fv_vec: Vec<usize> = fv.iter().copied().collect();
+            fv_vec.sort();
+            let rewrite = fv_vec
+                .iter()
+                .enumerate()
+                .map(|(i, old_index)| (*old_index, i + 1))
+                .collect();
+            rewrite_expr(body, &rewrite, arity);
+            fv_vec.reverse();
+            *captured = fv_vec;
+            fv
+        }
+        Let { bound, body, .. } => {
+            let mut fv = convert_fv(bound);
+            fv.extend(unshift_fv(convert_fv(body), 1));
+            fv
+        }
+        Case { scrut, alts } => {
+            let mut fv = convert_fv(scrut);
+            for alt in alts {
+                fv.extend(unshift_fv(
+                    convert_fv(&mut alt.body),
+                    alt.pattern.binders().len(),
+                ));
+            }
+            fv
+        }
+        _ => {
+            let mut fv = HashSet::new();
+            for child in expr.children_mut() {
+                fv.extend(convert_fv(child));
+            }
+            fv
+        }
+    }
+}
+
+impl Expr {
+    pub fn closure_convert(mut self) -> Self {
+        convert_fv(&mut self);
+        self
+    }
+}

--- a/src/ast/iter.rs
+++ b/src/ast/iter.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+use super::{Alt, Expr};
+
+pub struct ChildrenMut<'a> {
+    expr1: Option<&'a mut Expr>,
+    expr2: Option<&'a mut Expr>,
+    exprs: std::slice::IterMut<'a, Expr>,
+    alts: std::slice::IterMut<'a, Alt>,
+}
+
+impl<'a> ChildrenMut<'a> {
+    fn new(
+        expr1: Option<&'a mut Expr>,
+        expr2: Option<&'a mut Expr>,
+        exprs: std::slice::IterMut<'a, Expr>,
+    ) -> Self {
+        let alts = [].iter_mut();
+        ChildrenMut {
+            expr1,
+            expr2,
+            exprs,
+            alts,
+        }
+    }
+}
+
+impl<'a> Iterator for ChildrenMut<'a> {
+    type Item = &'a mut Expr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.expr1
+            .take()
+            .or_else(|| self.expr2.take())
+            .or_else(|| self.exprs.next())
+            .or_else(|| self.alts.next().map(|alt| &mut alt.body))
+    }
+}
+
+impl Expr {
+    pub fn children_mut(&mut self) -> ChildrenMut {
+        use Expr::*;
+        match self {
+            Var { .. }
+            | Val { .. }
+            | Builtin(_)
+            | PrimLit(_)
+            | EnumCon { .. }
+            | GetTime
+            | Unsupported(_) => ChildrenMut::new(None, None, [].iter_mut()),
+            RecCon { exprs, .. } | TupleCon { exprs, .. } => {
+                ChildrenMut::new(None, None, exprs.iter_mut())
+            }
+            RecProj { record: expr, .. }
+            | VariantCon { arg: expr, .. }
+            | TupleProj { tuple: expr, .. }
+            | Lam { body: expr, .. }
+            | Create { payload: expr, .. }
+            | Fetch {
+                contract_id: expr, ..
+            }
+            | AdvanceTime { delta: expr }
+            | Located { expr, .. } => ChildrenMut::new(Some(expr), None, [].iter_mut()),
+            RecUpd {
+                record: expr1,
+                value: expr2,
+                ..
+            }
+            | Let {
+                bound: expr1,
+                body: expr2,
+                ..
+            }
+            | Exercise {
+                contract_id: expr1,
+                arg: expr2,
+                ..
+            }
+            | Submit {
+                submitter: expr1,
+                update: expr2,
+                ..
+            } => ChildrenMut::new(Some(expr1), Some(expr2), [].iter_mut()),
+            App {
+                fun: expr1,
+                args: exprs,
+            } => ChildrenMut::new(Some(expr1), None, exprs.iter_mut()),
+            Case { scrut, alts } => ChildrenMut {
+                expr1: Some(scrut),
+                expr2: None,
+                exprs: [].iter_mut(),
+                alts: alts.iter_mut(),
+            },
+        }
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -47,7 +47,7 @@ pub enum Value<'a> {
     Map(FnvHashMap<String, Rc<Value<'a>>>),
     Token, // The "real world" token for the `Update` monad.
     PAP(Builtin, Vec<Rc<Value<'a>>>, usize),
-    Lam(&'a Expr, Env<'a>, Vec<Rc<Value<'a>>>, usize),
+    Lam(&'a Expr, Rc<Vec<Rc<Value<'a>>>>, Vec<Rc<Value<'a>>>, usize),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This has the huge benefit that we don't need to clone the whole stack
every time we allocate a closure but can rather put only the captured
values in the closure. This has improved the running time of the
collect-authority from 111ms to 92ms (-16%) on my machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/rusty-engine/13)
<!-- Reviewable:end -->
