### PR TITLE
Put World and Store into State rather than passing it around

### DIFF
--- a/benches/scenario.rs
+++ b/benches/scenario.rs
@@ -36,8 +36,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 let mut store = Store::new();
                 let entry_point =
                     make_entry_point(&world, String::from(*module), String::from(*scenario));
-                let state = State::init(&entry_point);
-                let _result = state.run(&world, &mut store);
+                let state = State::new(&entry_point, &world, &mut store);
+                let _result = state.run();
             })
         },
     );

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -391,6 +391,7 @@ pub struct Package {
     pub modules: FnvHashMap<String, Module>,
 }
 
+#[derive(Debug)]
 pub struct World {
     pub main: PackageId,
     packages: FnvHashMap<PackageId, Package>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@ mod tests {
                 println!("Test:   {}", test_name);
                 let mut store = Store::new();
                 let entry_point = make_entry_point(&world, module.name.clone(), value.name.clone());
-                let state = State::init(&entry_point);
-                let result = state.run(&world, &mut store);
+                let state = State::new(&entry_point, &world, &mut store);
+                let result = state.run();
 
                 let expected_failure = expected_failures.get(&(&module.name, &value.name));
                 match (result, expected_failure) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,8 @@ fn main() -> std::io::Result<()> {
             let start = Instant::now();
             let mut store = Store::new();
             let entry_point = make_entry_point(&world, module.name.clone(), value.name.clone());
-            let state = State::init(&entry_point);
-            let result = state.run(&world, &mut store);
+            let state = State::new(&entry_point, &world, &mut store);
+            let result = state.run();
             let duration = start.elapsed();
             let (active, archived) = store.stats();
 


### PR DESCRIPTION
We want to add a top-level value cache in the same way in a follow-up
PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/rusty-engine/15)
<!-- Reviewable:end -->
