### PR TITLE
Add a cache for evaluated top-level values

### DIFF
--- a/benches/scenario.rs
+++ b/benches/scenario.rs
@@ -34,8 +34,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         |b, (world, module, scenario)| {
             b.iter(|| {
                 let mut store = Store::new();
-                let entry_point =
-                    make_entry_point(&world, String::from(*module), String::from(*scenario));
+                let entry_point = world.entry_point(module, scenario);
                 let state = State::new(&entry_point, &world, &mut store);
                 let _result = state.run();
             })

--- a/src/ast/from_proto.rs
+++ b/src/ast/from_proto.rs
@@ -337,7 +337,11 @@ impl Expr {
                 } else {
                     panic!("items and id both set for internable string list")
                 };
-                Expr::Val { module_ref, name }
+                Expr::Val {
+                    module_ref,
+                    name,
+                    index: usize::MAX,
+                }
             }
             builtin(daml_lf_1::BuiltinFunction::TEXTMAP_EMPTY) => Expr::PrimLit(PrimLit::MapEmpty),
             builtin(x) => Expr::Builtin(Builtin::from_proto(x)),
@@ -849,7 +853,7 @@ impl Expr {
 }
 
 impl DefValue {
-    fn from_proto(proto: daml_lf_1::DefValue, env: &mut Env) -> Self {
+    fn from_proto(proto: daml_lf_1::DefValue, module_ref: &ModuleRef, env: &mut Env) -> Self {
         let name_with_type = proto.name_with_type.unwrap();
         let name = if name_with_type.name_dname.len() == 0 {
             env.get_interned_dotted_name(name_with_type.name_interned_dname)
@@ -859,13 +863,21 @@ impl DefValue {
             panic!("items and id both set for internable string list")
         };
         let location = Location::from_proto(proto.location, env);
+        let index = usize::MAX;
+        let self_ref = Expr::Val {
+            module_ref: module_ref.clone(),
+            name: name.clone(),
+            index,
+        };
         let expr = Expr::from_proto(proto.expr, env).closure_convert();
         let is_test = proto.is_test;
         DefValue {
             name,
             location,
+            self_ref,
             expr,
             is_test,
+            index,
         }
     }
 }
@@ -1044,7 +1056,7 @@ impl Module {
             .values
             .into_iter()
             .map(|x| {
-                let y = DefValue::from_proto(x, env);
+                let y = DefValue::from_proto(x, &self_ref, env);
                 (y.name.clone(), y)
             })
             .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,18 +12,6 @@ pub use crate::ast::{DefValue, Module, World};
 pub use crate::cesk::State;
 pub use crate::store::Store;
 
-use crate::ast::{Expr, ModuleRef};
-
-pub fn make_entry_point(world: &World, module_name: String, scenario_name: String) -> Expr {
-    Expr::Val {
-        module_ref: ModuleRef {
-            package_id: world.main.clone(),
-            module_name,
-        },
-        name: scenario_name,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,7 +29,7 @@ mod tests {
                 let test_name = format!("{}:{}", module.name, value.name);
                 println!("Test:   {}", test_name);
                 let mut store = Store::new();
-                let entry_point = make_entry_point(&world, module.name.clone(), value.name.clone());
+                let entry_point = world.entry_point(&module.name, &value.name);
                 let state = State::new(&entry_point, &world, &mut store);
                 let result = state.run();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,8 @@ fn main() -> std::io::Result<()> {
             println!("Test:      {}", test_name);
             let start = Instant::now();
             let mut store = Store::new();
-            let entry_point = make_entry_point(&world, module.name.clone(), value.name.clone());
-            let state = State::new(&entry_point, &world, &mut store);
+            let entry_point = world.entry_point(&module.name, &value.name);
+            let state = State::new(entry_point, &world, &mut store);
             let result = state.run();
             let duration = start.elapsed();
             let (active, archived) = store.stats();


### PR DESCRIPTION
The cache is not shared between different instance of the CEK machine.

In order to make finding values in the cache efficient, we give every
top-level value declaration an index and refer to top-level values by
their indices. This requires an additional indexing pass when loading
the world.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/rusty-engine/16)
<!-- Reviewable:end -->
