### PR TITLE
Avoid cloning some Rc<Value>'s we actually own

### DIFF
--- a/src/cesk.rs
+++ b/src/cesk.rs
@@ -478,8 +478,8 @@ impl<'a, 'store> State<'a, 'store> {
             }
             Prim::Lam(body, captured) => {
                 self.kont.push(Kont::Pop(captured.len() + args.len()));
-                self.env.push_many(&captured);
-                self.env.push_many(&args);
+                self.env.push_slice(&captured);
+                self.env.push_vec(args);
                 Ctrl::Expr(body)
             }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -72,8 +72,12 @@ impl<'a> Env<'a> {
         self.stack.push(value);
     }
 
-    pub fn push_many(&mut self, args: &[Rc<Value<'a>>]) {
+    pub fn push_slice(&mut self, args: &[Rc<Value<'a>>]) {
         self.stack.extend_from_slice(args);
+    }
+
+    pub fn push_vec(&mut self, mut args: Vec<Rc<Value<'a>>>) {
+        self.stack.append(&mut args);
     }
 
     pub fn pop(&mut self) -> Rc<Value<'a>> {


### PR DESCRIPTION
The perfomance improvement is insignificant on the `collect-authority`
benchmark and around 1.02x on a computation heavier benchmark.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/rusty-engine/22)
<!-- Reviewable:end -->
