### PR TITLE
Don't use environment for create/exercise communication

### DIFF
--- a/src/cesk.rs
+++ b/src/cesk.rs
@@ -484,34 +484,43 @@ impl<'a, 'store> State<'a, 'store> {
             }
 
             Prim::CreateCall(template) => {
-                let payload = Rc::clone(&args[0]);
-
-                // NOTE(MH): We don't add a pop continuation for the `payload`
-                // since `CreateExec` will pop it.
-                self.env.push(payload);
+                let payload = &args[0];
+                self.kont.push(Kont::Pop(1));
+                self.env.push(Rc::clone(&payload));
                 self.kont.push(Kont::Arg(&template.precondtion));
-                Ctrl::from_prim(Prim::CreateCheckPrecondition(template), 1)
+                Ctrl::PAP(PAP {
+                    prim: Prim::CreateCheckPrecondition(template),
+                    args,
+                    missing: 1,
+                })
             }
             Prim::CreateCheckPrecondition(template) => {
-                let payload = self.env.top();
-                let precondtion: bool = args[0].as_bool();
+                let payload = &args[0];
+                let precondtion: bool = args[1].as_bool();
                 if !precondtion {
                     Ctrl::Error(format!(
                         "Template pre-condition violated for {}: {:?}",
                         template.self_ref, payload
                     ))
                 } else {
+                    self.kont.push(Kont::Pop(1));
+                    self.env.push(Rc::clone(&payload));
                     self.kont.push(Kont::Arg(&template.observers));
                     self.kont.push(Kont::Arg(&template.signatories));
-                    Ctrl::from_prim(Prim::CreateExec(template), 2)
+                    let mut args = args;
+                    args.truncate(1);
+                    Ctrl::PAP(PAP {
+                        prim: Prim::CreateExec(template),
+                        args,
+                        missing: 2,
+                    })
                 }
             }
             Prim::CreateExec(template) => {
-                let payload = self.env.pop();
                 let update_mode = self.mode.as_update_mode();
-
-                let signatories = args[0].as_party_set();
-                let observers = args[1].as_party_set();
+                let payload = &args[0];
+                let signatories = args[1].as_party_set();
+                let observers = args[2].as_party_set();
                 if !signatories.is_subset(&update_mode.authorizers) {
                     Ctrl::Error(format!(
                         "authorization missing for create {}: {:?}",
@@ -523,7 +532,7 @@ impl<'a, 'store> State<'a, 'store> {
 
                     let contract_id = self.store.create(Contract {
                         template_ref: &template.self_ref,
-                        payload,
+                        payload: Rc::clone(payload),
                         signatories,
                         observers,
                         witnesses,
@@ -554,29 +563,34 @@ impl<'a, 'store> State<'a, 'store> {
             Prim::ExerciseCall(choice) => Ctrl::catch(|| {
                 let update_mode = self.mode.as_update_mode();
                 let contract_id = &args[0];
+                let arg = &args[1];
                 let contract = self.store.fetch(
                     &update_mode.submitter,
                     &update_mode.witnesses,
                     &choice.template_ref,
                     contract_id.as_contract_id(),
                 )?;
-                let payload = Rc::clone(&contract.payload);
-                let arg = Rc::clone(&args[1]);
+                let payload = &contract.payload;
 
-                // NOTE(MH): We pop 3 elements since `ExerciseExec` will
-                // pop `arg`, push a `contract_id` and push `arg` again.
-                self.kont.push(Kont::Pop(3));
-                self.env.push(payload);
-                self.env.push(arg);
-                self.kont.push(Kont::ArgVal(Rc::clone(contract_id)));
+                self.kont.push(Kont::Pop(2));
+                self.env.push(Rc::clone(&payload));
+                self.env.push(Rc::clone(&arg));
                 self.kont.push(Kont::Arg(&choice.controllers));
-                Ok(Ctrl::from_prim(Prim::ExerciseExec(choice), 2))
+                let mut args = args;
+                args.reserve(2);
+                args.push(Rc::clone(payload));
+                Ok(Ctrl::PAP(PAP {
+                    prim: Prim::ExerciseExec(choice),
+                    args,
+                    missing: 1,
+                }))
             }),
             Prim::ExerciseExec(choice) => Ctrl::catch(|| {
                 let update_mode = self.mode.as_mut_update_mode();
-                let controllers = args[0].as_party_set();
-                let contract_id = &args[1];
-                let arg = self.env.pop();
+                let contract_id = &args[0];
+                let arg = &args[1];
+                let payload = &args[2];
+                let controllers = args[3].as_party_set();
 
                 if !controllers.is_subset(&update_mode.authorizers) {
                     Err(format!(
@@ -608,8 +622,10 @@ impl<'a, 'store> State<'a, 'store> {
                         )?;
                     }
 
+                    self.kont.push(Kont::Pop(3));
+                    self.env.push(Rc::clone(payload));
                     self.env.push(Rc::clone(contract_id));
-                    self.env.push(arg);
+                    self.env.push(Rc::clone(arg));
 
                     let old_authorizers =
                         std::mem::replace(&mut update_mode.authorizers, new_authorizers);

--- a/src/value.rs
+++ b/src/value.rs
@@ -64,10 +64,6 @@ impl<'a> Env<'a> {
             .expect("Bad de Bruijn index")
     }
 
-    pub fn top(&self) -> &Rc<Value<'a>> {
-        self.stack.last().expect("Top on empty stack")
-    }
-
     pub fn push(&mut self, value: Rc<Value<'a>>) {
         self.stack.push(value);
     }
@@ -78,10 +74,6 @@ impl<'a> Env<'a> {
 
     pub fn push_vec(&mut self, mut args: Vec<Rc<Value<'a>>>) {
         self.stack.append(&mut args);
-    }
-
-    pub fn pop(&mut self) -> Rc<Value<'a>> {
-        self.stack.pop().expect("Pop from empty stack")
     }
 
     pub fn pop_many(&mut self, count: usize) {


### PR DESCRIPTION
Currently, the first steps of `create`/`exercise` push values into the
environment which are popped by the later steps. This prevents us from
optimizing the environment usage. Thus, this PR changes the
communication between the separate `create`/`exercise` steps to use the
`args` field of the PAPs they allocate anyway.

This change has no observable performance impact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/rusty-engine/24)
<!-- Reviewable:end -->
